### PR TITLE
add email sending logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'

--- a/src/main/java/EFUB/homepage/controller/ContactController.java
+++ b/src/main/java/EFUB/homepage/controller/ContactController.java
@@ -1,0 +1,28 @@
+package EFUB.homepage.controller;
+
+import EFUB.homepage.dto.ContactDto;
+import EFUB.homepage.dto.MailDto;
+import EFUB.homepage.service.ContactService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api")
+public class ContactController {
+
+	public final ContactService contactService;
+
+	@PostMapping("/contact")
+	public void sendMail(@RequestBody ContactDto contactDto) {
+		String email = contactDto.getWriter_email();
+		String title = "[EFUB 문의]";
+		String content = contactDto.getContent();
+
+		MailDto mailDto = new MailDto(email, title, content);
+		contactService.mailSend(mailDto);
+	}
+}

--- a/src/main/java/EFUB/homepage/dto/MailDto.java
+++ b/src/main/java/EFUB/homepage/dto/MailDto.java
@@ -1,0 +1,19 @@
+package EFUB.homepage.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MailDto {
+
+	private String email;
+	private String title;
+	private String content;
+
+	public MailDto(String email, String title, String content) {
+		this.email = email;
+		this.title = title;
+		this.content = content;
+	}
+}

--- a/src/main/java/EFUB/homepage/service/ContactService.java
+++ b/src/main/java/EFUB/homepage/service/ContactService.java
@@ -1,0 +1,28 @@
+package EFUB.homepage.service;
+
+import EFUB.homepage.dto.MailDto;
+import lombok.AllArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@AllArgsConstructor
+@Service
+public class ContactService {
+
+	private JavaMailSender mailSender;
+	private static final String TO_ADDRESS = "ewhaefub@gmail.com";
+
+	public void mailSend(MailDto mailDto) {
+		try {
+			MailHandler mailHandler = new MailHandler(mailSender);
+			mailHandler.setTo(ContactService.TO_ADDRESS);
+			mailHandler.setFrom(mailDto.getEmail());
+			mailHandler.setSubject("[EFUB 문의 메일]");
+			String htmlContent = "<p>" + mailDto.getContent() + "<p>" + mailDto.getEmail() + "<p>";
+			mailHandler.setText(htmlContent, true);
+			mailHandler.send();
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/java/EFUB/homepage/service/MailHandler.java
+++ b/src/main/java/EFUB/homepage/service/MailHandler.java
@@ -33,10 +33,10 @@ public class MailHandler {
 		messageHelper.setText(text, useHtml);
 	}
 
-	public void send(){
-		try{
+	public void send() {
+		try {
 			sender.send(message);
-		} catch (Exception e){
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/EFUB/homepage/service/MailHandler.java
+++ b/src/main/java/EFUB/homepage/service/MailHandler.java
@@ -1,0 +1,43 @@
+package EFUB.homepage.service;
+
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+public class MailHandler {
+	private JavaMailSender sender;
+	private MimeMessage message;
+	private MimeMessageHelper messageHelper;
+
+	public MailHandler(JavaMailSender jsender) throws MessagingException {
+		this.sender = jsender;
+		message = jsender.createMimeMessage();
+		messageHelper = new MimeMessageHelper(message, true, "UTF-8");
+	}
+
+	public void setFrom(String fromAddress) throws MessagingException {
+		messageHelper.setFrom(fromAddress);
+	}
+
+	public void setTo(String email) throws MessagingException {
+		messageHelper.setTo(email);
+	}
+
+	public void setSubject(String subject) throws MessagingException {
+		messageHelper.setSubject(subject);
+	}
+
+	public void setText(String text, boolean useHtml) throws MessagingException {
+		messageHelper.setText(text, useHtml);
+	}
+
+	public void send(){
+		try{
+			sender.send(message);
+		} catch (Exception e){
+			e.printStackTrace();
+		}
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,17 @@ spring.datasource.url=jdbc:mysql://efub-homepage.cz96r5ylajtt.ap-northeast-2.rds
 spring.datasource.username=root
 spring.datasource.password=efubsince2021##
 
+#mail connect
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=
+spring.mail.password=
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.debug=true
+spring.mail.properties.mail.smtp.EnableSSL.enable=true
+spring.mail.properties.smtp.socketFactory.port=587
+spring.mail.properties.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+spring.mail.properties.smtp.socketFactory.callback=false
+
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
메일을 보낼 때는 메일 주소와 비밀번호가 필요하지만, 받을 때는 메일 주소만 필요함.
[Contact] 사용자가 메일을 보내면 이펍 계정이 받는 형식인데, 사용자의 계정 비밀번호를 받을 수 없기 때문에 application.properties에 선언되어 있는 계정이 메일을 보내게 됨.

-> 일단 이메일 내용에 질문 내용 + 사용자의 이메일 주소를 첨부해 놓음.