### PR TITLE
add designer/lead developer apply and save logic

### DIFF
--- a/src/main/java/EFUB/homepage/controller/ApplyController.java
+++ b/src/main/java/EFUB/homepage/controller/ApplyController.java
@@ -2,11 +2,9 @@ package EFUB.homepage.controller;
 
 import EFUB.homepage.domain.Position;
 import EFUB.homepage.domain.User;
+import EFUB.homepage.dto.design.DesReqDto;
 import EFUB.homepage.dto.develop.DevReqDto;
-import EFUB.homepage.service.DevelopService;
-import EFUB.homepage.service.InterviewService;
-import EFUB.homepage.service.ToolService;
-import EFUB.homepage.service.UserService;
+import EFUB.homepage.service.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApplyController {
     private final UserService userService;
     private final ToolService toolService;
-//    private final DesignService designService;
+    private final DesignService designService;
     private final DevelopService developService;
     private final InterviewService interviewService;
 
@@ -40,6 +38,16 @@ public class ApplyController {
         return ResponseEntity.ok(200);
     }
 
+    @PostMapping("/design")
+    public ResponseEntity<Object> applyDesign(@RequestBody DesReqDto desReqDto){
+        User user = userService.save(desReqDto.getUser(), Position.Designer);
+
+        toolService.save(user, desReqDto.getTools());
+        interviewService.save(user, desReqDto.getInterviews());
+        designService.save(user, desReqDto.getApply());
+
+        return ResponseEntity.ok(200);
+    }
 /*
     @PostMapping("/get/des")
     public ResponseEntity<Object> getDesign(final @RequestBody UidDto uidDto) {

--- a/src/main/java/EFUB/homepage/domain/Design.java
+++ b/src/main/java/EFUB/homepage/domain/Design.java
@@ -1,6 +1,8 @@
 package EFUB.homepage.domain;
 
+import EFUB.homepage.dto.design.DesApplyDto;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,40 +21,50 @@ public class Design extends BaseTimeEntity {
 	@JoinColumn(name = "user_id")
 	private User user;
 
-	@Column(length = 350)
+	@Column(length = 300)
 	private String motive;
-
-	private int confidenceDes;
 
 	private int confidenceTool;
 
-	private String projectTopic;
+	@Column(length = 300)
+	private String activityPlan;
 
-	@Column(length = 5000)
-	private String expDev;
-
-	@Column(length = 5000)
-	private String expDes;
+	@Column(length = 300)
+	private String expSolve;
 
 	private String link;
 
-	private Boolean interview;
-
 	private Boolean orientation;
 
-//	@Builder
-//	public Design(User user, String motive, int confidenceDes, int confidenceTool, String projectTopic,
-//				  String expDes, String expDev, String link, Boolean interview, Boolean orientation) {
-//		this.user = user;
-//		this.motive = motive;
-//		this.confidenceDes = confidenceDes;
-//		this.confidenceTool = confidenceTool;
-//		this.projectTopic = projectTopic;
-//		this.expDes = expDes;
-//		this.expDev = expDev;
-//		this.link = link;
-//		this.interview = interview;
-//		this.orientation = orientation;
-//	}
+	@Builder
+	public Design(User user, String motive, int confidenceTool, String activityPlan,
+				  String expSolve, String link, Boolean orientation) {
+		this.user = user;
+		this.motive = motive;
+		this.confidenceTool = confidenceTool;
+		this.activityPlan = activityPlan;
+		this.expSolve = expSolve;
+		this.link = link;
+		this.orientation = orientation;
+	}
+
+	private void setUser(User user) {
+		this.user = user;
+		user.setDesign(this);
+	}
+
+	public static Design createDesign(User user, DesApplyDto apply) {
+		Design design = Design.builder()
+			.motive(apply.getMotive())
+			.confidenceTool(apply.getConfidenceTool())
+			.activityPlan(apply.getActivityPlan())
+			.expSolve(apply.getExpSolve())
+			.link(apply.getLink())
+			.orientation(apply.getOrientation())
+			.build();
+		design.setUser(user);
+
+		return design;
+	}
 }
 

--- a/src/main/java/EFUB/homepage/domain/Develop.java
+++ b/src/main/java/EFUB/homepage/domain/Develop.java
@@ -19,9 +19,10 @@ public abstract class Develop extends BaseTimeEntity {
 	@JoinColumn(name = "user_id")
 	protected User user;
 
-	@Column(length = 350)
+	@Column(length = 300)
 	protected String motive;
 
+	@Column(length = 100)
 	protected String projectTopic;
 
 	protected String applicationField;

--- a/src/main/java/EFUB/homepage/domain/Develop.java
+++ b/src/main/java/EFUB/homepage/domain/Develop.java
@@ -31,13 +31,12 @@ public abstract class Develop extends BaseTimeEntity {
 
 	protected Integer confidenceLang;
 
-	@Column(length = 1000)
 	protected String link;
 
 	protected Boolean orientation;
 
 	public Develop(String motive, String projectTopic, String applicationField,
-		   String language, Integer confidenceLang, String link, Boolean orientation) {
+				   String language, Integer confidenceLang, String link, Boolean orientation) {
 		this.motive = motive;
 		this.projectTopic = projectTopic;
 		this.applicationField = applicationField;

--- a/src/main/java/EFUB/homepage/domain/Intern.java
+++ b/src/main/java/EFUB/homepage/domain/Intern.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
@@ -14,14 +15,16 @@ import javax.persistence.Entity;
 @DiscriminatorValue("I")
 @Slf4j
 public class Intern extends Develop {
+	@Column(length = 500)
 	private String expProject;
+
+	@Column(length = 500)
 	private String expStudy;
-	private String toolName;
 
 	@Builder
 	public Intern(String motive, String projectTopic, String applicationField, String language,
 				  Integer confidenceLang, String link, Boolean orientation, String expProject,
-				  String expStudy, String toolName) {
+				  String expStudy) {
 		super.motive = motive;
 		super.projectTopic = projectTopic;
 		super.applicationField = applicationField;
@@ -31,7 +34,6 @@ public class Intern extends Develop {
 		super.orientation = orientation;
 		this.expProject = expProject;
 		this.expStudy = expStudy;
-		this.toolName = toolName;
 	}
 
 	public void setUser(User user) {
@@ -41,17 +43,16 @@ public class Intern extends Develop {
 
 	public static Intern createIntern(User user, DevApplyDto apply) {
 		Intern intern = Intern.builder()
-				.motive(apply.getMotive())
-				.projectTopic(apply.getProjectTopic())
-				.applicationField(apply.getApplicationField())
-				.language(apply.getLanguage())
-				.confidenceLang(apply.getConfidenceLang())
-				.link(apply.getLink())
-				.orientation(apply.getOrientation())
-				.expProject(apply.getExpProject())
-				.expStudy(apply.getExpStudy())
-				.toolName(apply.getToolName())
-				.build();
+			.motive(apply.getMotive())
+			.projectTopic(apply.getProjectTopic())
+			.applicationField(apply.getApplicationField())
+			.language(apply.getLanguage())
+			.confidenceLang(apply.getConfidenceLang())
+			.link(apply.getLink())
+			.orientation(apply.getOrientation())
+			.expProject(apply.getExpProject())
+			.expStudy(apply.getExpStudy())
+			.build();
 		intern.setUser(user);
 
 		return intern;

--- a/src/main/java/EFUB/homepage/domain/Intern.java
+++ b/src/main/java/EFUB/homepage/domain/Intern.java
@@ -47,7 +47,7 @@ public class Intern extends Develop {
 				.language(apply.getLanguage())
 				.confidenceLang(apply.getConfidenceLang())
 				.link(apply.getLink())
-				.orientation(apply.getOrietation())
+				.orientation(apply.getOrientation())
 				.expProject(apply.getExpProject())
 				.expStudy(apply.getExpStudy())
 				.toolName(apply.getToolName())

--- a/src/main/java/EFUB/homepage/domain/Lead.java
+++ b/src/main/java/EFUB/homepage/domain/Lead.java
@@ -1,8 +1,11 @@
 package EFUB.homepage.domain;
 
+import EFUB.homepage.dto.develop.DevApplyDto;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 
@@ -10,7 +13,51 @@ import javax.persistence.Entity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @DiscriminatorValue("L")
 public class Lead extends Develop {
+	@Column(length = 500)
 	private String expProject;
+
+	@Column(length = 300)
 	private String expSolve;
+
+	@Column(length = 100)
 	private String seminarTopic;
+
+	@Builder
+	public Lead(String motive, String projectTopic, String applicationField, String language,
+				Integer confidenceLang, String link, Boolean orientation, String expProject,
+				String expSolve, String seminarTopic) {
+		super.motive = motive;
+		super.projectTopic = projectTopic;
+		super.applicationField = applicationField;
+		super.language = language;
+		super.confidenceLang = confidenceLang;
+		super.link = link;
+		super.orientation = orientation;
+		this.expProject = expProject;
+		this.expSolve = expSolve;
+		this.seminarTopic = seminarTopic;
+	}
+
+	public void setUser(User user) {
+		super.user = user;
+		user.setDevelop(this);
+	}
+
+	public static Lead createLead(User user, DevApplyDto apply) {
+		Lead lead = Lead.builder()
+			.motive(apply.getMotive())
+			.projectTopic(apply.getProjectTopic())
+			.applicationField(apply.getApplicationField())
+			.language(apply.getLanguage())
+			.confidenceLang(apply.getConfidenceLang())
+			.link(apply.getLink())
+			.orientation(apply.getOrientation())
+			.expProject(apply.getExpProject())
+			.expSolve(apply.getExpSolve())
+			.seminarTopic(apply.getSeminarTopic())
+			.build();
+		lead.setUser(user);
+
+		return lead;
+	}
 }

--- a/src/main/java/EFUB/homepage/domain/User.java
+++ b/src/main/java/EFUB/homepage/domain/User.java
@@ -13,7 +13,7 @@ import static javax.persistence.FetchType.LAZY;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "users")
+@Entity(name = "user")
 public class User {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -66,4 +66,6 @@ public class User {
 	public void setDevelop(Develop develop) {
 		this.develop = develop;
 	}
+
+	public void setDesign(Design design) { this.design = design;}
 }

--- a/src/main/java/EFUB/homepage/dto/design/DesApplyDto.java
+++ b/src/main/java/EFUB/homepage/dto/design/DesApplyDto.java
@@ -1,0 +1,13 @@
+package EFUB.homepage.dto.design;
+
+import lombok.Getter;
+
+@Getter
+public class DesApplyDto {
+	private String motive;
+	private Integer confidenceTool;
+	private String activityPlan;
+	private String expSolve;
+	private String link;
+	private Boolean orientation;
+}

--- a/src/main/java/EFUB/homepage/dto/design/DesReqDto.java
+++ b/src/main/java/EFUB/homepage/dto/design/DesReqDto.java
@@ -1,0 +1,16 @@
+package EFUB.homepage.dto.design;
+
+import EFUB.homepage.dto.common.UserReqDto;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class DesReqDto {
+	private UserReqDto user;
+	private List<String> tools;
+	private List<String> interviews;
+	private DesApplyDto apply;
+}

--- a/src/main/java/EFUB/homepage/dto/develop/DevApplyDto.java
+++ b/src/main/java/EFUB/homepage/dto/develop/DevApplyDto.java
@@ -10,7 +10,7 @@ public class DevApplyDto {
 	private String language;
 	private Integer confidenceLang;
 	private String link;
-	private Boolean orietation;
+	private Boolean orientation;
 	private String expProject;
 	private String expSolve;
 	private String seminarTopic;

--- a/src/main/java/EFUB/homepage/dto/develop/DevApplyDto.java
+++ b/src/main/java/EFUB/homepage/dto/develop/DevApplyDto.java
@@ -15,5 +15,4 @@ public class DevApplyDto {
 	private String expSolve;
 	private String seminarTopic;
 	private String expStudy;
-	private String toolName;
 }

--- a/src/main/java/EFUB/homepage/repository/LeadRepository.java
+++ b/src/main/java/EFUB/homepage/repository/LeadRepository.java
@@ -1,0 +1,9 @@
+package EFUB.homepage.repository;
+
+import EFUB.homepage.domain.Lead;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LeadRepository extends JpaRepository<Lead, Long> {
+}

--- a/src/main/java/EFUB/homepage/service/DesignService.java
+++ b/src/main/java/EFUB/homepage/service/DesignService.java
@@ -1,57 +1,20 @@
 package EFUB.homepage.service;
 
+import EFUB.homepage.domain.Design;
+import EFUB.homepage.domain.User;
+import EFUB.homepage.dto.design.DesApplyDto;
 import EFUB.homepage.repository.DesignRepository;
-import EFUB.homepage.repository.ToolRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class DesignService {
     private final DesignRepository designRepository;
-    private final ToolRepository toolRepository;
 
-//    @Transactional
-//    public boolean checkByUserId(Long userId){
-//        if(designRepository.findByUserId(userId).isEmpty()){
-//            return false;
-//        }
-//        return true;
-//    }
-
-//    @Transactional
-//    public Design save(DesignDto designDto){
-//        return designRepository.save(designDto.toEntity());
-//    }
-//
-//    @Transactional
-//    public boolean update(UpdateDesignDto updateDesignDto){
-//        Long desId = updateDesignDto.getDes_id();
-//        Optional<Design> designOp = designRepository.findById(desId);
-//        if(designOp.isEmpty()){
-//            return false;
-//        }
-//        Design design = designOp.get();
-//        design.update(updateDesignDto.getMotive(),
-//                updateDesignDto.getConfidence_des(),
-//                updateDesignDto.getConfidence_tool(),
-//                updateDesignDto.getProject_topic(),
-//                updateDesignDto.getExp_des(),
-//                updateDesignDto.getExp_dev(),
-//                updateDesignDto.getLink(),
-//                updateDesignDto.getInterview(),
-//                updateDesignDto.getOrientation());
-//        return true;
-//    }
-//
-//    @Transactional(readOnly = true)
-//	public DesignResDto getDesign(Long user_id) {
-//        Optional<Design> design = designRepository.findByUserId(user_id);
-//        if (design.isEmpty())
-//            return (new Design()).toDesignResDto(null);
-//
-//        List<ToolResDto> tools = toolRepository.findByUserId(user_id)
-//            .stream().map(Tool::toToolResDto).collect(Collectors.toList());
-//        return design.get().toDesignResDto(tools);
-//	}
+    @Transactional
+    public void save(User user, DesApplyDto apply){
+        designRepository.save(Design.createDesign(user, apply));
+    }
 }

--- a/src/main/java/EFUB/homepage/service/DevelopService.java
+++ b/src/main/java/EFUB/homepage/service/DevelopService.java
@@ -1,9 +1,11 @@
 package EFUB.homepage.service;
 
 import EFUB.homepage.domain.Intern;
+import EFUB.homepage.domain.Lead;
 import EFUB.homepage.domain.User;
 import EFUB.homepage.dto.develop.DevApplyDto;
 import EFUB.homepage.repository.InternRepository;
+import EFUB.homepage.repository.LeadRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -14,17 +16,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Slf4j
 public class DevelopService {
-    private final InternRepository internRepository;
+	private final InternRepository internRepository;
+	private final LeadRepository leadRepository;
 
-    @Transactional
-    public void save(User user, DevApplyDto apply) {
-        if (apply.getApplicationField().startsWith("인턴")) {
-            log.info("서비스에서 확인: " + apply.getToolName());
-            internRepository.save(Intern.createIntern(user, apply));
-        }
-        // Todo: 리드 부분 인턴과 동일하게 개발
-//        else {
-//            developRepository.save(Lead.createLead(user, apply));
-//        }
-    }
+	@Transactional
+	public void save(User user, DevApplyDto apply) {
+		if (apply.getApplicationField().startsWith("인턴")) {
+			internRepository.save(Intern.createIntern(user, apply));
+		} else {
+			leadRepository.save(Lead.createLead(user, apply));
+		}
+	}
 }


### PR DESCRIPTION
1. 기획 변경으로 인한 DB column 수정
- design : projectTopic, expDes, expDev 삭제 / activityPlan, expSolve 추가
- develop : 인턴 개발자의 toolName column 삭제

2. 디자이너 save logic 추가
3. 리드 개발자 save logic 추가
4. DB column 변경으로 인한 api 문서 및 변수명 오탈자 수정