### PR TITLE
fix contact error

### DIFF
--- a/src/main/java/EFUB/homepage/controller/ContactController.java
+++ b/src/main/java/EFUB/homepage/controller/ContactController.java
@@ -4,6 +4,7 @@ import EFUB.homepage.dto.contact.ContactDto;
 import EFUB.homepage.dto.contact.MailDto;
 import EFUB.homepage.service.ContactService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/EFUB/homepage/controller/LoginController.java
+++ b/src/main/java/EFUB/homepage/controller/LoginController.java
@@ -26,7 +26,7 @@ public class LoginController {
     @PostMapping("/login")
     public String login(@RequestBody LoginReqDto loginReqDto) {
         Admin member = service.findUser(loginReqDto);
-        if(member == null) throw new IllegalArgumentException("가입되지않은 이메일입니다");
+        if(member == null) throw new IllegalArgumentException("잘못된 아이디입니다.");
         if(!passwordEncoder.matches(loginReqDto.getPassword(), member.getPassword())) {
             throw new IllegalArgumentException("잘못된 비밀번호입니다.");
         }

--- a/src/main/java/EFUB/homepage/service/ContactService.java
+++ b/src/main/java/EFUB/homepage/service/ContactService.java
@@ -4,14 +4,18 @@ import EFUB.homepage.dto.contact.ContactDto;
 import EFUB.homepage.dto.contact.MailDto;
 import EFUB.homepage.repository.ContactRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
+@Component
 public class ContactService {
 	private final ContactRepository contactRepository;
 
+	@Autowired
 	private JavaMailSender mailSender;
 	private static final String TO_ADDRESS = "ewhaefub@gmail.com";
 

--- a/src/main/java/EFUB/homepage/service/LoginService.java
+++ b/src/main/java/EFUB/homepage/service/LoginService.java
@@ -27,9 +27,8 @@ public class LoginService implements UserDetailsService {
     }
 
     @Transactional
-    public Admin findUser(LoginReqDto dto) {
-        Admin member = repository.findByAdminId(dto.getAdminId());
-        return member;
+    public Admin findUser(LoginReqDto loginReqDto) {
+        return repository.findByAdminId(loginReqDto.getAdminId());
     }
 
     @Override


### PR DESCRIPTION
javaMailSender에서 `NullPointerException`이 발생하는 문제 해결
- 객체를 직접 생성해서 @Autowired로 DI 되지 않아서 생성하는 문제였습니다. @Bean으로 의존성 주입하여 해결했습니다.