### PR TITLE
add passwordEncoder when find pass result and refactor optional

### DIFF
--- a/src/main/java/EFUB/homepage/config/AdminDetail.java
+++ b/src/main/java/EFUB/homepage/config/AdminDetail.java
@@ -1,6 +1,7 @@
 package EFUB.homepage.config;
 
-import EFUB.homepage.domain.Admin;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -8,15 +9,17 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
+@NoArgsConstructor
 public class AdminDetail implements UserDetails {
     private String adminId;
     private String password;
     private String auth;
 
-    public AdminDetail(Admin admin) {
-        this.adminId = admin.getAdminId();
-        this.password = admin.getPassword();
-        this.auth = "ROLE_" + admin.getRole();
+    @Builder
+    public AdminDetail(String adminId, String password, String auth) {
+        this.adminId = adminId;
+        this.password = password;
+        this.auth = "ROLE_" + auth;
     }
 
     @Override

--- a/src/main/java/EFUB/homepage/controller/ApplyController.java
+++ b/src/main/java/EFUB/homepage/controller/ApplyController.java
@@ -29,15 +29,15 @@ public class ApplyController {
     private final InterviewService interviewService;
 
 
-    @PostMapping("/apply/develop")
-    public ResponseEntity<Object> applyDevelop(@RequestBody UserReqDto userReqDto){
+    @PostMapping("/check/develop")
+    public ResponseEntity<Object> checkDevelop(@RequestBody UserReqDto userReqDto){
         if (userService.checkDuplicateUsers(userReqDto, Position.DEVELOPER_LEAD) || userService.checkDuplicateUsers(userReqDto, Position.DEVELOPER_INTERN))
             throw new DuplicateUserException();
         return ResponseEntity.ok(200);
     }
 
-    @PostMapping("/apply/design")
-    public ResponseEntity<Object> applyDesign(@RequestBody UserReqDto userReqDto){
+    @PostMapping("/check/design")
+    public ResponseEntity<Object> checkDesign(@RequestBody UserReqDto userReqDto){
         if (userService.checkDuplicateUsers(userReqDto, Position.DESIGNER))
             throw new DuplicateUserException();
         return ResponseEntity.ok(200);

--- a/src/main/java/EFUB/homepage/controller/LoginController.java
+++ b/src/main/java/EFUB/homepage/controller/LoginController.java
@@ -7,9 +7,13 @@ import EFUB.homepage.exception.NoSuchAdminException;
 import EFUB.homepage.service.LoginService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,11 +25,12 @@ public class LoginController {
 
     @PostMapping("/login")
     public String login(@Valid @RequestBody LoginReqDto loginReqDto) {
-        Admin member = service.findUser(loginReqDto);
-        if(member == null) throw new NoSuchAdminException("잘못된 아이디입니다.");
-        if(!passwordEncoder.matches(loginReqDto.getPassword(), member.getPassword())) {
+        Optional<Admin> optionalAdmin = service.findUser(loginReqDto);
+        if(optionalAdmin.isEmpty()) throw new NoSuchAdminException("잘못된 아이디입니다.");
+        Admin admin = optionalAdmin.get();
+        if(!passwordEncoder.matches(loginReqDto.getPassword(), admin.getPassword())) {
             throw new NoSuchAdminException("잘못된 비밀번호입니다.");
         }
-        return jwtTokenProvider.createToken(member.getAdminId(), member.getRole());
+        return jwtTokenProvider.createToken(admin.getAdminId(), admin.getRole());
     }
 }

--- a/src/main/java/EFUB/homepage/domain/Admin.java
+++ b/src/main/java/EFUB/homepage/domain/Admin.java
@@ -1,5 +1,6 @@
 package EFUB.homepage.domain;
 
+import EFUB.homepage.config.AdminDetail;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,6 @@ import javax.persistence.*;
 @Getter
 @Entity
 @NoArgsConstructor
-@Table(name="admin")
 public class Admin {
 
     @Id
@@ -30,5 +30,13 @@ public class Admin {
         this.adminId = adminId;
         this.password =password;
         role = "ADMIN";
+    }
+
+    public AdminDetail toAdminDetail() {
+        return AdminDetail.builder()
+                .adminId(adminId)
+                .auth(role)
+                .password(password)
+                .build();
     }
 }

--- a/src/main/java/EFUB/homepage/dto/login/LoginReqDto.java
+++ b/src/main/java/EFUB/homepage/dto/login/LoginReqDto.java
@@ -9,7 +9,6 @@ import javax.validation.constraints.NotBlank;
 
 @NoArgsConstructor
 @Getter
-@Setter
 public class LoginReqDto {
 
     @NotBlank

--- a/src/main/java/EFUB/homepage/dto/pass/PassResultResDto.java
+++ b/src/main/java/EFUB/homepage/dto/pass/PassResultResDto.java
@@ -1,11 +1,11 @@
 package EFUB.homepage.dto.pass;
 
 import lombok.Builder;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor
-@Data
 public class PassResultResDto {
 	private String result;
 

--- a/src/main/java/EFUB/homepage/repository/AdminRepository.java
+++ b/src/main/java/EFUB/homepage/repository/AdminRepository.java
@@ -4,8 +4,10 @@ import EFUB.homepage.domain.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
-	Admin findByAdminId(String adminId);
+	Optional<Admin> findByAdminId(String adminId);
 }
 

--- a/src/main/java/EFUB/homepage/repository/UserRepository.java
+++ b/src/main/java/EFUB/homepage/repository/UserRepository.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByNameAndStudentIdAndPosition(String name, String studentId, Position position);
-    User findByNameAndPhoneNo(String name, String phoneNo);
+    Optional<User> findByNameAndPhoneNo(String name, String phoneNo);
     List<User> findAllByPosition(Position position);
     List<User> findAllByPositionAndPassMid(Position position, Boolean order);
     Optional<User> findByUserIdAndPosition(Long userId, Position position);

--- a/src/main/java/EFUB/homepage/service/LoginService.java
+++ b/src/main/java/EFUB/homepage/service/LoginService.java
@@ -10,6 +10,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,13 +18,13 @@ public class LoginService implements UserDetailsService {
     private final AdminRepository repository;
 
     @Transactional
-    public Admin findUser(LoginReqDto loginReqDto) {
+    public Optional<Admin> findUser(LoginReqDto loginReqDto) {
         return repository.findByAdminId(loginReqDto.getAdminId());
     }
 
     @Override
-    public AdminDetail loadUserByUsername(String adminId) throws UsernameNotFoundException {
-        Admin admin = repository.findByAdminId(adminId);
-        return new AdminDetail(admin);
+    public AdminDetail loadUserByUsername(String adminId) {
+        return repository.findByAdminId(adminId).map(Admin::toAdminDetail)
+                .orElseThrow(() -> new UsernameNotFoundException("유저 id를 찾을 수 없습니다"));
     }
 }

--- a/src/main/java/EFUB/homepage/service/PassService.java
+++ b/src/main/java/EFUB/homepage/service/PassService.java
@@ -5,65 +5,55 @@ import EFUB.homepage.dto.pass.PassDto;
 import EFUB.homepage.dto.pass.PassResultResDto;
 import EFUB.homepage.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Objects;
+import java.util.Optional;
 
 
 @RequiredArgsConstructor
 @Service
 public class PassService {
 	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
 
 	public PassResultResDto checkMidPass(PassDto passDto) {
-
-		User user = userRepository.findByNameAndPhoneNo(
-			passDto.getName(),
-			passDto.getPhoneNo()
+		Optional<User> optionalUser = userRepository.findByNameAndPhoneNo(
+				passDto.getName(),
+				passDto.getPhoneNo()
 		);
 
-		Boolean isPass;
-		String result;
-
-		if (user == null) { // 등록된 유저가 없는 경우
-			return new PassResultResDto("잘못된 정보입니다.");
+		if (optionalUser.isEmpty()) { // 등록된 유저가 없는 경우
+			return PassResultResDto.builder().result("잘못된 정보입니다.").build();
+		} else {
+			User user = optionalUser.get();
+			if (!passwordEncoder.matches(passDto.getPassword(), user.getPassword())) {
+				return PassResultResDto.builder().result("비밀번호가 틀립니다.").build();
+			} else {
+				return PassResultResDto.builder().result(getPassResult(user.getPassMid())).build();
+			}
 		}
-		if (!Objects.equals(user.getPassword(), passDto.getPassword())) {
-			return new PassResultResDto("비밀번호가 틀립니다.");
-		}
-
-		isPass = user.getPassMid();
-		if (isPass)
-			result = "합격";
-		else
-			result = "불합격";
-
-		return new PassResultResDto(result);
 	}
 
 	public PassResultResDto checkFinPass(PassDto passDto) {
-
-		User user = userRepository.findByNameAndPhoneNo(
-			passDto.getName(),
-			passDto.getPhoneNo()
+		Optional<User> optionalUser = userRepository.findByNameAndPhoneNo(
+				passDto.getName(),
+				passDto.getPhoneNo()
 		);
 
-		Boolean isPass;
-		String result;
-
-		if (user == null) { // 등록된 유저가 없는 경우
-			return new PassResultResDto("잘못된 정보입니다.");
+		if (optionalUser.isEmpty()) { // 등록된 유저가 없는 경우
+			return PassResultResDto.builder().result("잘못된 정보입니다.").build();
+		} else {
+			User user = optionalUser.get();
+			if (!passwordEncoder.matches(passDto.getPassword(), user.getPassword())) {
+				return PassResultResDto.builder().result("비밀번호가 틀립니다.").build();
+			} else {
+				return PassResultResDto.builder().result(getPassResult(user.getPassFinal())).build();
+			}
 		}
-		if (!Objects.equals(user.getPassword(), passDto.getPassword())) {
-			return new PassResultResDto("비밀번호가 틀립니다.");
-		}
+	}
 
-		isPass = user.getPassFinal();
-		if (isPass)
-			result = "합격";
-		else
-			result = "불합격";
-
-		return new PassResultResDto(result);
+	private String getPassResult(Boolean passMid) {
+		return passMid ? "합격" : "불합격";
 	}
 }


### PR DESCRIPTION
- ResDto, ReqDto 의 경우, `@Getter`와 `@NoArgsContructor`만 사용하면 됩니다.
  - `@Data`의 경우 불필요한 코드가 많이 생성되어 비효율적이고 `@Data` 대신, `@Getter`, `@Setter`, `@ToString`으로 명시하는 것을 권장합니다. 
  - java 객체에서 json으로 바인딩 될 때, 또는 반대로 바인딩 될 때 사용하는 것이 기본 생성자입니다.
  - ...Apply...Dto와 같이 Res, Req도 아닌 객체는 json으로의 변환이 필요하지 않기에 값을 가져다 쓸 수 있는 `@Getter`만 사용하면 될 것 같습니다.
  - 참고로 하나 더, entity의 경우 jpa 지원 스펙에서 기본 생성자가 있어야 하는데, access level을 public 에서 protected까지 허용합니다. 그래서 현재 모두 protected로 구현되어 있습니다.
- 지원할 때 지원자의 paasword는 암호화되는데 합격 확인 시에 복호화하여 비교하고 있지 않아 오류를 수정했습니다.
- Optional를 활용하도록 군데군데 리팩토링했습니다. findBy... 로 db에서 하나의 엔티티를 찾아올 때는 찾아오고 나서 null로 판단하는 것보다 `Optional`을 사용해 제공해주는 메서드를 사용하는 것을 매우 권장합니다 :> 